### PR TITLE
Update .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,8 @@ engines:
     enabled: true
   radon:
     enabled: true
+    config: 
+      python_version: 2
 ratings:
   paths:
   - "**.py"


### PR DESCRIPTION
Hi Jonas!

Jenna here from Code Climate. I saw your ticket come through to our support team and wanted to help out with some configuration changes.

Currently when you enable our Radon engine in your .codeclimate.yml it automatically defaults to assuming the target project is written for Python 3. Good news though, the engine can support projects written in Python version 2.x by making a small change in your .codeclimate.yml.

I've forked your repo, made the necessary changes and included them in this pull request. Feel free to merge it in. Thanks again for reaching out. Let me know if there's anything else I can do on my end to help.